### PR TITLE
feat: Implement Monetization and Marketplace UIs

### DIFF
--- a/frontend/src/app/marketplace/page.tsx
+++ b/frontend/src/app/marketplace/page.tsx
@@ -1,0 +1,42 @@
+// frontend/src/app/marketplace/page.tsx
+import React from 'react';
+
+const plugins = [
+  {
+    title: 'Advanced Analytics',
+    description: 'Unlock deep insights into your data with advanced analytics and visualizations.',
+  },
+  {
+    title: 'Collaboration Tools',
+    description: 'Work seamlessly with your team with real-time collaboration features.',
+  },
+  {
+    title: 'Custom Exporters',
+    description: 'Export your data in custom formats, including PDF, CSV, and Excel.',
+  },
+    {
+    title: 'AI Assistant',
+    description: 'Supercharge your workflow with an AI-powered assistant.',
+  },
+];
+
+const MarketplacePage = () => {
+  return (
+    <div className="container mx-auto p-4">
+      <h1 className="text-3xl font-bold mb-6">Plugin Marketplace</h1>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {plugins.map((plugin, index) => (
+          <div key={index} className="border rounded-lg p-4 flex flex-col">
+            <h2 className="text-xl font-semibold mb-2">{plugin.title}</h2>
+            <p className="text-gray-600 mb-4 flex-grow">{plugin.description}</p>
+            <button className="bg-blue-500 text-white font-bold py-2 px-4 rounded hover:bg-blue-700 mt-auto">
+              Install
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default MarketplacePage;

--- a/frontend/src/app/settings/billing/page.tsx
+++ b/frontend/src/app/settings/billing/page.tsx
@@ -1,12 +1,49 @@
+import React from 'react';
+
+const paymentHistory = [
+  { date: '2023-08-01', amount: '$20.00', status: 'Paid' },
+  { date: '2023-07-01', amount: '$20.00', status: 'Paid' },
+  { date: '2023-06-01', amount: '$20.00', status: 'Paid' },
+];
+
 export default function BillingPage() {
   return (
     <div>
       <h2 className="text-2xl font-bold mb-4">Billing & Subscription</h2>
-      <div className="bg-yellow-100 border-l-4 border-yellow-500 text-yellow-700 p-4" role="alert">
-        <p className="font-bold">Coming Soon!</p>
-        <p>This section is under construction. Manage your subscription and view invoices here in the future.</p>
+
+      <div className="mb-8">
+        <h3 className="text-xl font-semibold mb-2">Current Plan</h3>
+        <p className="text-gray-600">You are on the <span className="font-bold text-blue-600">Pro Plan</span>.</p>
+        <button className="mt-4 bg-blue-500 text-white font-bold py-2 px-4 rounded hover:bg-blue-700">
+          Manage Subscription
+        </button>
       </div>
-      {/* You could add more placeholder content here if needed */}
+
+      <div>
+        <h3 className="text-xl font-semibold mb-4">Payment History</h3>
+        <div className="overflow-x-auto">
+          <table className="min-w-full bg-white border">
+            <thead className="bg-gray-200">
+              <tr>
+                <th className="py-2 px-4 border-b">Date</th>
+                <th className="py-2 px-4 border-b">Amount</th>
+                <th className="py-2 px-4 border-b">Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {paymentHistory.map((payment, index) => (
+                <tr key={index} className="text-center">
+                  <td className="py-2 px-4 border-b">{payment.date}</td>
+                  <td className="py-2 px-4 border-b">{payment.amount}</td>
+                  <td className="py-2 px-4 border-b">
+                    <span className="bg-green-200 text-green-800 py-1 px-3 rounded-full text-sm">{payment.status}</span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/src/app/subscribe/page.tsx
+++ b/frontend/src/app/subscribe/page.tsx
@@ -1,0 +1,57 @@
+// frontend/src/app/subscribe/page.tsx
+import React from 'react';
+
+const tiers = [
+  {
+    name: 'Free',
+    price: '$0',
+    features: [
+      'Basic feature 1',
+      'Basic feature 2',
+      'Basic feature 3',
+    ],
+    buttonText: 'Current Plan',
+    buttonDisabled: true,
+  },
+  {
+    name: 'Pro',
+    price: '$20/month',
+    features: [
+      'All features in Free',
+      'Advanced feature 1',
+      'Advanced feature 2',
+      'Priority support',
+    ],
+    buttonText: 'Upgrade to Pro',
+    buttonDisabled: false,
+  },
+];
+
+const SubscribePage = () => {
+  return (
+    <div className="container mx-auto p-4">
+      <h1 className="text-3xl font-bold text-center mb-10">Choose Your Plan</h1>
+      <div className="flex justify-center gap-8">
+        {tiers.map((tier) => (
+          <div key={tier.name} className="border rounded-lg p-6 w-80 text-center flex flex-col">
+            <h2 className="text-2xl font-semibold mb-4">{tier.name}</h2>
+            <p className="text-4xl font-bold mb-6">{tier.price}</p>
+            <ul className="text-left mb-8 flex-grow">
+              {tier.features.map((feature, index) => (
+                <li key={index} className="mb-2">- {feature}</li>
+              ))}
+            </ul>
+            <button
+              className={`w-full py-2 px-4 rounded font-bold ${tier.buttonDisabled ? 'bg-gray-400' : 'bg-blue-500 hover:bg-blue-700 text-white'}`}
+              disabled={tier.buttonDisabled}
+            >
+              {tier.buttonText}
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default SubscribePage;

--- a/frontend/src/components/layouts/Sidebar.tsx
+++ b/frontend/src/components/layouts/Sidebar.tsx
@@ -1,9 +1,19 @@
 import React from 'react';
+import Link from 'next/link';
 
 const Sidebar = () => {
   return (
-    <aside className="w-64 bg-card text-card-foreground p-4 border-r">
-      <h2 className="text-lg font-bold">Sidebar</h2>
+    <aside className="w-64 bg-card text-card-foreground p-4 border-r flex flex-col">
+      <h2 className="text-lg font-bold mb-4">Sidebar</h2>
+
+      {/* Spacer to push the upgrade button to the bottom */}
+      <div className="flex-grow"></div>
+
+      <Link href="/subscribe" passHref>
+        <button className="w-full bg-green-500 text-white font-bold py-2 px-4 rounded hover:bg-green-700">
+          Upgrade to Pro
+        </button>
+      </Link>
     </aside>
   );
 };

--- a/frontend/src/components/ui/ExportButton.tsx
+++ b/frontend/src/components/ui/ExportButton.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMutation } from "@tanstack/react-query";
+import { useSubscription } from '@/hooks/useSubscription';
 
 const exportProject = async (projectId: string) => {
   console.log(`Exporting project ${projectId}`);
@@ -10,12 +11,12 @@ const exportProject = async (projectId: string) => {
   if (!res.ok) {
     throw new Error("Failed to start export process.");
   }
-  // The backend will handle the zip generation and download trigger.
-  // The response might be a confirmation message.
   return res.json();
 };
 
 export default function ExportButton({ projectId }: { projectId: string }) {
+  const { isPro, isLoading } = useSubscription();
+
   const mutation = useMutation({
     mutationFn: exportProject,
     onSuccess: () => {
@@ -26,13 +27,28 @@ export default function ExportButton({ projectId }: { projectId: string }) {
     },
   });
 
-  return (
+  const isDisabled = mutation.isPending || !isPro || isLoading;
+
+  const button = (
     <button
       onClick={() => mutation.mutate(projectId)}
-      disabled={mutation.isPending}
+      disabled={isDisabled}
       className="bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-4 rounded disabled:bg-gray-400"
     >
       {mutation.isPending ? "Exporting..." : "Export as .zip"}
     </button>
   );
+
+  if (!isPro && !isLoading) {
+    return (
+      <div className="relative group">
+        {button}
+        <div className="absolute bottom-full mb-2 w-max bg-black text-white text-xs rounded py-1 px-2 opacity-0 group-hover:opacity-100">
+          Upgrade to Pro to use this feature.
+        </div>
+      </div>
+    );
+  }
+
+  return button;
 }

--- a/frontend/src/hooks/useSubscription.ts
+++ b/frontend/src/hooks/useSubscription.ts
@@ -1,0 +1,9 @@
+// frontend/src/hooks/useSubscription.ts
+export const useSubscription = () => {
+  // In the future, this will be replaced with a real implementation
+  // that checks the user's subscription status from the backend.
+  return {
+    isPro: false,
+    isLoading: false,
+  };
+};


### PR DESCRIPTION
This commit introduces the UI for several new monetization and commercial features, as per requirements F14, F15, and F32.

- **Plugin Marketplace (F14):** Creates a new page at `/marketplace` that displays a grid of available plugins. Each plugin is represented by a card with a title, description, and an "Install" button. The data is currently hardcoded.

- **Subscription Management (F32):** Updates the existing billing page at `/settings/billing`. The new UI displays your current subscription plan, a "Manage Subscription" button, and a payment history table with placeholder data.

- **PRO Mode Gating (F15):**
  - Adds a new subscription tiers page at `/subscribe` to display "Free" and "Pro" plans.
  - Adds an "Upgrade to Pro" button to the sidebar, linking to the new subscribe page.
  - Implements a `useSubscription` hook with static data (`isPro: false`) to simulate checking your subscription status.
  - Uses this hook to gate the "Export" button, disabling it for non-pro users and showing a tooltip on hover.